### PR TITLE
Enable adding items from app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# B-squeda-y-visualizador-de-inventario
+# Búsqueda y visualizador de inventario
+
+Aplicación sencilla en Streamlit para cargar un archivo de inventario en formato
+CSV o XLSX, buscar información y ahora también añadir nuevos items. Tras añadir
+los productos se puede descargar un archivo actualizado sin modificar el
+documento original.


### PR DESCRIPTION
## Summary
- allow adding items via Streamlit form
- export updated inventory as Excel
- document the new workflow

## Testing
- `python -m py_compile inventario_online_v3.py`

------
https://chatgpt.com/codex/tasks/task_e_6851d78cffa8832bb169b9ad94fcbc94