### PR TITLE
Add preview step before downloading updated inventory

### DIFF
--- a/inventario_online_v3.py
+++ b/inventario_online_v3.py
@@ -230,6 +230,16 @@ def app():
             excel_bytes = tmp
             file_name = "inventario_actualizado.csv"
 
+        with st.expander("Previsualizar archivo"):
+            if st.session_state.get('extension') == '.xlsx':
+                preview_df = pd.read_excel(
+                    BytesIO(excel_bytes.getvalue()),
+                    sheet_name=st.session_state.get('hoja')
+                )
+            else:
+                preview_df = pd.read_csv(BytesIO(excel_bytes.getvalue()))
+            st.dataframe(preview_df)
+
         st.download_button(
             "Descargar inventario actualizado",
             data=excel_bytes,


### PR DESCRIPTION
## Summary
- show an expander to preview the updated file
- read `excel_bytes` back into a dataframe for display
- move download button below the preview

## Testing
- `python -m py_compile inventario_online_v3.py`


------
https://chatgpt.com/codex/tasks/task_e_6851e47a55c8832bbbe440f0e78cbbfd