### PR TITLE
Fix Arrow conversion error by dropping index columns

### DIFF
--- a/inventario_online_v3.py
+++ b/inventario_online_v3.py
@@ -32,6 +32,8 @@ def cargar_datos(archivo):
             st.session_state['hoja'] = None
             datos = pd.read_csv(archivo)
         datos.columns = datos.columns.str.strip()
+        # Elimina columnas creadas al guardar índices (p. ej. "Unnamed: 0")
+        datos = datos.loc[:, ~datos.columns.str.contains('^Unnamed')]
         datos = preparar_datos(datos)
         # Omitir columnas completamente vacías
         datos.dropna(axis=1, how='all', inplace=True)


### PR DESCRIPTION
## Summary
- ignore accidental `Unnamed` columns when loading data

## Testing
- `python3 -m py_compile inventario_online_v3.py`


------
https://chatgpt.com/codex/tasks/task_e_6851ec0551c0832b9fe2e26b5c7c949b